### PR TITLE
DRG_sprout: Switch to source built vendor.qti.hardware.perf@2.0.so

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -306,7 +306,9 @@ PRODUCT_PACKAGES += \
 
 # Power
 PRODUCT_PACKAGES += \
-    android.hardware.power-service-qti
+    android.hardware.power-service-qti \
+    vendor.qti.hardware.perf@2.0.vendor
+
 # Protobuf
 # FIXME: master: compat for libprotobuf
 # See https://android-review.googlesource.com/c/platform/prebuilts/vndk/v28/+/1109518

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -755,15 +755,11 @@ vendor/lib/libperfgluelayer.so
 vendor/lib/libqti-perfd-client.so
 vendor/lib/libqti-perfd.so
 vendor/lib/libqti-util.so
-vendor/lib/vendor.qti.hardware.perf@1.0.so
-vendor/lib/vendor.qti.hardware.perf@2.0.so
 vendor/lib64/libperfconfig.so
 vendor/lib64/libperfgluelayer.so
 vendor/lib64/libqti-perfd-client.so
 vendor/lib64/libqti-perfd.so
 vendor/lib64/libqti-util.so
-vendor/lib64/vendor.qti.hardware.perf@1.0.so
-vendor/lib64/vendor.qti.hardware.perf@2.0.so
 
 # Peripheral
 vendor/bin/pm-proxy


### PR DESCRIPTION
For some reason, any prebuilt ones from pre-R ROMs no longer work on R
and cause the following error:
  E ANDR-PERF: Unable to link to gPerfHal death notifications!

Change-Id: I1dc96e4a51c4c81dd847c59a58ec670d89054f64
Signed-off-by: Omkar Chandorkar <gotenksIN@aosip.dev>